### PR TITLE
Generate .env from sample in entrypoint

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+APP_DIR="/var/www/dns"
+
+# Generate .env from env-sample using current environment variables
+if [ -f "$APP_DIR/env-sample" ]; then
+    envsubst < "$APP_DIR/env-sample" > "$APP_DIR/.env"
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary
- create .env from env-sample during container startup

## Testing
- `bash -n docker/entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_e_6898d317b5f0832ab838ad468675c0f3