### PR TITLE
chore: fix caddy repo setup RUN command

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -15,8 +15,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends gettext-base
 
 RUN rm -rf /var/lib/apt/lists/*
 
-RUN curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' -o caddy-stable.gpg.key \
-    gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg caddy-stable.gpg.key \
+RUN curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' -o caddy-stable.gpg.key && \
+    gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg caddy-stable.gpg.key && \
+    rm -f caddy-stable.gpg.key && \
     curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | tee /etc/apt/sources.list.d/caddy-stable.list
 
 RUN apt update 


### PR DESCRIPTION
## Summary
- properly chain Caddy repository setup commands in dockerfile
- remove temporary GPG key file after import

## Testing
- `composer test` *(fails: Command "test" is not defined)*
- `composer validate`
- `docker --version` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6898d62ec074832ab0f62b074bc5767e