### PR TITLE
Start Caddy from entrypoint script

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,4 +8,7 @@ if [ -f "$APP_DIR/env-sample" ]; then
     envsubst < "$APP_DIR/env-sample" > "$APP_DIR/.env"
 fi
 
+# Start Caddy in the background
+caddy run --config /etc/caddy/Caddyfile --adapter caddyfile &
+
 exec "$@"

--- a/dockerfile
+++ b/dockerfile
@@ -30,8 +30,6 @@ RUN mv env-sample .env
 
 COPY docker/Caddyfile /etc/caddy/Caddyfile
 
-RUN systemctl enable caddy
-
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 


### PR DESCRIPTION
## Summary
- Remove systemd dependency and start Caddy within entrypoint
- Launch Caddy alongside PHP-FPM using background process

## Testing
- `bash -n docker/entrypoint.sh`
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6898dbb37828832abcb7c3d7390bb32d