### PR TITLE
fix env substitution in entrypoint

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,7 +5,21 @@ APP_DIR="/var/www/dns"
 
 # Generate .env from env-sample using current environment variables
 if [ -f "$APP_DIR/env-sample" ]; then
-    envsubst < "$APP_DIR/env-sample" > "$APP_DIR/.env"
+    while IFS= read -r line; do
+        # Skip comments and empty lines
+        if [[ -z "$line" || "$line" == \#* ]]; then
+            printf '%s\n' "$line"
+            continue
+        fi
+
+        key=${line%%=*}
+
+        if [ "${!key+x}" ]; then
+            printf '%s=%s\n' "$key" "${!key}"
+        else
+            printf '%s\n' "$line"
+        fi
+    done < "$APP_DIR/env-sample" > "$APP_DIR/.env"
 fi
 
 # Start Caddy in the background


### PR DESCRIPTION
## Summary
- ensure entrypoint correctly substitutes environment variables into `.env`

## Testing
- `bash -n docker/entrypoint.sh`
- `APP_NAME=TestName APP_URL=http://test.local bash docker/entrypoint.sh cat /var/www/dns/.env`

------
https://chatgpt.com/codex/tasks/task_e_6898dd57dc30832a95271aae851d0758