### PR TITLE
Configure session cookie domain from APP_DOMAIN

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -22,6 +22,19 @@ if [ -f "$APP_DIR/env-sample" ]; then
     done < "$APP_DIR/env-sample" > "$APP_DIR/.env"
 fi
 
+# Configure PHP session cookie domain if APP_DOMAIN is set
+if [ -n "${APP_DOMAIN}" ]; then
+    for INI in /etc/php/8.3/cli/php.ini /etc/php/8.3/fpm/php.ini; do
+        if [ -f "$INI" ]; then
+            if grep -q '^\s*;\?\s*session\.cookie_domain' "$INI"; then
+                sed -i -E "s/^\s*;?\s*session\.cookie_domain\s*=.*/session.cookie_domain = ${APP_DOMAIN}/" "$INI"
+            else
+                echo "session.cookie_domain = ${APP_DOMAIN}" >> "$INI"
+            fi
+        fi
+    done
+fi
+
 # Start Caddy in the background
 caddy run --config /etc/caddy/Caddyfile --adapter caddyfile &
 


### PR DESCRIPTION
## Summary
- set `session.cookie_domain` in CLI and FPM php.ini using `APP_DOMAIN`

## Testing
- `bash -n docker/entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_e_6898decab018832a8b9ccada508114fa